### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ Here's an example of functional template repository structure
 │   │           │           ├── README.md
 │   │           │           └── stale.yml
 │   │           └── template.json                        # Template meta data file
-│   └── applications                                     # Application type specific CI templates
-│       └── web_app                                      # CI templates for the app type 'web_app'
-│           └── acceptance                               # Acceptance test templates
+│   └── web_app                                          # CI templates for the app type 'web_app'
+│       └── acceptance                                   # Acceptance test templates
 │               └── GitHub                               # Acceptance test template for GitHub
 │                   └── robot_framework                  # Template for running Robot Framework on GitHub
 │                       ├── ...                          # Files & folders to copy to the new repo root


### PR DESCRIPTION
In order to accurately reflect the directory structure, remove the mention of an "application" folder containing application type specific CI templates.