### PR TITLE
Deploy React with Python to AWS

### DIFF
--- a/applications/web_app/frontend/react_with_rest/template.json
+++ b/applications/web_app/frontend/react_with_rest/template.json
@@ -14,14 +14,12 @@
       "build": {
         "context": "",
         "args": [
-          "BACKEND_API_URL=${BACKEND_API_URL}"
+          "BACKEND_API_URL=${BACKEND_API_URL}",
+          "DEPLOY_PUBLIC_ADDRESS=${DEPLOY_PUBLIC_ADDRESS}"
         ]
       },
-      "environment": {
-        "PORT": 80
-      },
       "ports": [
-        "80:80"
+        "80:8000"
       ]
     }
   }

--- a/applications/web_app/frontend/react_with_rest/template/.env.development
+++ b/applications/web_app/frontend/react_with_rest/template/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_API_URL=http://localhost:8080
+REACT_APP_BACKEND_API_URL=http://localhost:9000

--- a/applications/web_app/frontend/react_with_rest/template/Dockerfile
+++ b/applications/web_app/frontend/react_with_rest/template/Dockerfile
@@ -16,7 +16,9 @@ RUN yarn build
 FROM nginx:1.21.0-alpine as production
 
 ARG BACKEND_API_URL
-ENV BACKEND_API_URL=${BACKEND_API_URL}
+ARG DEPLOY_PUBLIC_ADDRESS
+ENV BACKEND_API_URL=${BACKEND_API_URL:-http://${DEPLOY_PUBLIC_ADDRESS}}
+ENV PORT=8000
 
 # Copy built assets from builder
 COPY --from=builder /app/build /usr/share/nginx/html

--- a/applications/web_app/frontend/react_with_rest/template/package.json.j2
+++ b/applications/web_app/frontend/react_with_rest/template/package.json.j2
@@ -39,5 +39,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:9000"
 }

--- a/applications/web_app/rest/python/template.json
+++ b/applications/web_app/rest/python/template.json
@@ -7,7 +7,7 @@
   "appType": "backend",
   "requires": [
     {
-      "url": "https://github.com/EficodeEntDemo/python-rest-api-template.git",
+      "url": "https://github.com/jpvg10/python-rest-api-template.git",
       "paths": [
         "/"
       ]
@@ -19,11 +19,8 @@
       "build": {
         "context": ""
       },
-      "environment": {
-        "PORT": 8080
-      },
       "ports": [
-        "8080:8080"
+        "9000:9000"
       ]
     }
   }

--- a/applications/web_app/rest/python/template.json
+++ b/applications/web_app/rest/python/template.json
@@ -7,7 +7,7 @@
   "appType": "backend",
   "requires": [
     {
-      "url": "https://github.com/jpvg10/python-rest-api-template.git",
+      "url": "https://github.com/EficodeEntDemo/python-rest-api-template.git",
       "paths": [
         "/"
       ]

--- a/deployment/AWS/EKS/Fullstack EKS/template/build-deploy.sh.j2
+++ b/deployment/AWS/EKS/Fullstack EKS/template/build-deploy.sh.j2
@@ -1,7 +1,7 @@
 {% raw -%}
 #!/bin/bash
 
-test -z "$PROJECT_NAME" && test -f .env.development && \
+test -z "$PROJECT_NAME" && test -f .env.deploy && \
   PROJECT_NAME=$(grep -e '^DEPLOY_PROJECT_NAME=.*' .env.deploy | cut -d '=' -f2)
 
 dockerPrefix="${PROJECT_NAME}"

--- a/deployment/AWS/EKS/Fullstack EKS/template/build-deploy.sh.j2
+++ b/deployment/AWS/EKS/Fullstack EKS/template/build-deploy.sh.j2
@@ -1,3 +1,4 @@
+{% raw -%}
 #!/bin/bash
 
 test -z "$PROJECT_NAME" && test -f .env.development && \
@@ -31,6 +32,10 @@ EOF
 
 buildDevImages() {
   set -x
+{%- endraw %}
+
+  {% if ctx.templates['fullstack_zeroday-fullstack'] -%}
+  {% raw -%}
   docker-compose \
   --verbose \
   -f docker-compose.yml \
@@ -40,11 +45,31 @@ buildDevImages() {
 
   docker tag ${dockerPrefix}_frontend-dev ${dockerPrefix}_frontend-dev:${version}
   docker tag ${dockerPrefix}_backend-dev ${dockerPrefix}_backend-dev:${version}
+  {%- endraw %}
+  {% else %}
+  {% raw -%}
+  docker-compose \
+  --verbose \
+  -f docker-compose.yml \
+  --project-directory . \
+  -p ${dockerPrefix} \
+  build frontend_react_with_rest rest_python
+
+  docker tag ${dockerPrefix}_frontend_react_with_rest ${dockerPrefix}_frontend-dev:${version}
+  docker tag ${dockerPrefix}_rest_python ${dockerPrefix}_backend-dev:${version}
+  {%- endraw %}
+  {% endif %}
+
+{% raw -%}
   set +x
 }
 
 buildProdImages() {
   set -x  
+{%- endraw %}
+
+  {% if ctx.templates['fullstack_zeroday-fullstack'] -%}
+  {% raw -%}
   docker-compose \
     -f compose/production.yml \
     -f compose/db.yml \
@@ -61,6 +86,22 @@ buildProdImages() {
 
   docker tag ${dockerPrefix}_frontend ${dockerPrefix}_frontend-prod:${version}
   docker tag ${dockerPrefix}_backend ${dockerPrefix}_backend-prod:${version}
+  {%- endraw %}
+  {% else %}
+  {% raw -%}
+  docker-compose \
+  --verbose \
+  -f docker-compose.yml \
+  --project-directory . \
+  -p ${dockerPrefix} \
+  build frontend_react_with_rest rest_python
+
+  docker tag ${dockerPrefix}_frontend_react_with_rest ${dockerPrefix}_frontend-prod:${version}
+  docker tag ${dockerPrefix}_rest_python ${dockerPrefix}_backend-prod:${version}
+  {%- endraw %}
+  {% endif %}
+
+{% raw -%}
   set +x
 }
 ### Functions end
@@ -105,3 +146,4 @@ else
 fi
 
 echo "Done, exiting."
+{%- endraw %}

--- a/deployment/AWS/EKS/Fullstack EKS/template/package.json.j2
+++ b/deployment/AWS/EKS/Fullstack EKS/template/package.json.j2
@@ -1,0 +1,8 @@
+{
+  "name": "{{ctx.current_template['repository_name']}}",
+  "author": "{{ctx.current_template['PROJECT_AUTHOR']}}",
+  "version": "0.0.1",
+  "description": "{{ctx.current_template['PROJECT_DESCRIPTION']}}",
+  "license": "",
+  "private": true
+}


### PR DESCRIPTION
- Using port 8000 in the React frontend and 9000 in the Python backend.
- Templating the `build-deploy.sh` script to build and tag the Docker images correctly depending on the templates being used.
- Adding `package.json` the deployment template, so that every project deployed with AWS has a `package.json`.